### PR TITLE
Remove require magit-process

### DIFF
--- a/magit-gitflow.el
+++ b/magit-gitflow.el
@@ -35,7 +35,6 @@
 
 (require 'magit)
 (require 'magit-popup)
-(require 'magit-process)
 
 (defvar magit-gitflow-mode-lighter " GitFlow")
 


### PR DESCRIPTION
I had to remove the (require 'magit-process) line in order to make magit-gitflow work again. It seems to be ok just to remove it. I have not seen any problems with it yet, but you might want to double check all features before release.. :)
